### PR TITLE
Fix Social Media Activity Fetch Bug

### DIFF
--- a/src/main/java/io/antmedia/AppSettings.java
+++ b/src/main/java/io/antmedia/AppSettings.java
@@ -126,6 +126,8 @@ public class AppSettings {
 
 	public static final String SETTINGS_DEFAULT_DECODERS_ENABLED = "settings.defaultDecodersEnabled";
 
+	public static final String SETTINGS_COLLECT_SOCIAL_MEDIA_ACTIVITY_ENABLED = "settings.collectSocialMediaActivityEnabled";
+
 	
 	@JsonIgnore
 	@NotSaved
@@ -372,7 +374,8 @@ public class AppSettings {
 	/**
 	 * If it's enabled, interactivity(like, comment,) is collected from social media channel
 	 */
-	private boolean collectSocialMediaActivity = false;
+    @Value( "${" + SETTINGS_COLLECT_SOCIAL_MEDIA_ACTIVITY_ENABLED +":false}")
+	private boolean collectSocialMediaActivity;
 
 	
 	@Value( "${" + SETTINGS_ENCODING_ENCODER_NAME +":#{null}}")


### PR DESCRIPTION
Social media comments cannot be fetched. Reason is setting configuration item is not exposed to properties file. So it is false by default. 

Steps:
1. Added Facebook to test.antmedi.io
2. Added facebook to a stream.
3. Started a live stream.
4. Watched the stream at facebook.
5. Wrote comments to live stream.
6. Called https://test.antmedia.io:5443/rest/request?_path=WebRTCAppEE/rest/v2/broadcasts/id/social-endpoints/endpointid/live-comments-count
7. Received:{"success":true,"message":"0","dataId":null,"errorId":0}