### PR TITLE
Add endpoint parameter to AmazonS3StorageClient

### DIFF
--- a/src/main/java/io/antmedia/storage/AmazonS3StorageClient.java
+++ b/src/main/java/io/antmedia/storage/AmazonS3StorageClient.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import com.amazonaws.client.builder.AwsClientBuilder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,12 @@ public class AmazonS3StorageClient extends StorageClient {
 	private AmazonS3 getAmazonS3() {
 		if (amazonS3 == null) {
 			AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
+
+			// Inject endpoint if provided in the configuration file
+			if (getEndpoint() != null && getRegion() != null) {
+				builder = builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(getEndpoint(), getRegion()));
+			}
+
 			// Inject credentials if provided in the configuration file
 			if (getAccessKey() != null) {
 				BasicAWSCredentials awsCredentials = new BasicAWSCredentials(getAccessKey(), getSecretKey());
@@ -48,8 +55,6 @@ public class AmazonS3StorageClient extends StorageClient {
 	                .withConnectionTimeout(120 * 1000)
 	                .withMaxErrorRetry(15));
 			
-			//.withConnectionTimeout(120 * 1000)
-            //.withMaxErrorRetry(15))
 			amazonS3 = builder.build();
 		}
 		return amazonS3; 

--- a/src/main/java/io/antmedia/storage/StorageClient.java
+++ b/src/main/java/io/antmedia/storage/StorageClient.java
@@ -23,7 +23,8 @@ public abstract class StorageClient {
 			return value;
 		}
 	}
-	
+
+	private String endpoint;
 	private String accessKey;
 	private String secretKey;
 	private String region;
@@ -72,6 +73,14 @@ public abstract class StorageClient {
 	 * @return
 	 */
 	public abstract boolean fileExist(String key);
+
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(String endpoint) {
+		this.endpoint = endpoint;
+	}
 
 	public String getAccessKey() {
 		return accessKey;


### PR DESCRIPTION
Add opportunity to change default S3 endpoint to be able to store files at S3 compatible storages like Digital Ocean Storage, MinIO.